### PR TITLE
Fixed bug in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A collection of resources for learning cybersecurity
 - [Youtube](#youtube)
 - [Platform](#platform)
 - [Reddit](#reddit)
-- [Online Material](#features)
+- [Online Material](#usage)
 
 <br/>
 


### PR DESCRIPTION
When the online material link was clicked it didn't transfer screen to the site of heading 
Now its fixed